### PR TITLE
Get rid of allocations from `split`

### DIFF
--- a/oh_my_glob.go
+++ b/oh_my_glob.go
@@ -31,6 +31,13 @@ type Glob struct {
 }
 
 func Compile(glob string) Glob {
+	if glob == "" {
+		return Glob{
+			original: "",
+			parts:    nil,
+		}
+	}
+
 	var parts []part
 	for _, fragment := range strings.Split(glob, "/") {
 		if fragment == "**" {
@@ -95,42 +102,72 @@ func match(pattern, name string) bool {
 }
 
 func (g *Glob) Match(path string) bool {
-	chunks := strings.Split(path, "/")
+	// `px` is the index into the current path part
 	px := 0
+	// `nx` is the index into the string, which will change in
+	// strides based on where we find `/` characters
 	nx := 0
+	// these are used for backtracking in the case of `**`,
+	// c.f. the Russ Cox page linked above
 	nextPx := 0
 	nextNx := 0
 
-	for px < len(g.parts) || nx < len(chunks) {
+	for px < len(g.parts) || nx < len(path) {
+		// This is a little hairy: `incrNx` is going to be the
+		// "next" `nx` value, and we'll only ever need it if
+		// `nx < len(path)` above. `nx` should always point to
+		// the beginning of a path segment _or_ to the end of
+		// the path. We start searching from the current `nx`
+		// and find the next '/' character
+		incrNx := 0
+		if nx < len(path) {
+			tx := strings.IndexByte(path[nx:], '/')
+
+			if tx < 0 {
+				incrNx = len(path)
+			} else {
+				incrNx = nx + tx + 1
+			}
+		}
+
 		if px < len(g.parts) {
 			c := g.parts[px]
 			switch c.stars {
 			case 0:
-				if nx < len(chunks) && match(c.lit, chunks[nx]) {
-					px++
-					nx++
-					continue
+				if nx < len(path) {
+					// find the next substring
+					var chunk string
+					if incrNx == len(path) {
+						chunk = path[nx:]
+					} else {
+						chunk = path[nx : incrNx-1]
+					}
+
+					if match(c.lit, chunk) {
+						px++
+						nx = incrNx
+						continue
+					}
 				}
 			case 2:
 				nextPx = px
-				nextNx = nx + 1
+				nextNx = incrNx
 				px++
 				continue
 			case 1:
-				if nx < len(chunks) {
+				if nx < len(path) {
 					px++
-					nx++
+					nx = incrNx
 					continue
 				}
 			default:
 				// this should never happen and
 				// indicates a bug in library code
 				log.Fatalf("Unexpected compiled glob value")
-
 			}
 		}
 
-		if 0 < nextNx && nextNx <= len(chunks) {
+		if 0 < nextNx && nextNx <= len(path) {
 			px = nextPx
 			nx = nextNx
 			continue


### PR DESCRIPTION
This previously would split the path into segments and look at them individually, but this isn't necessary: we can walk along the path by finding the index of the next `/` component, which avoids extra allocations.