### PR TITLE
glob matching optimizations

### DIFF
--- a/oh_my_glob.go
+++ b/oh_my_glob.go
@@ -5,21 +5,27 @@ import (
 	"strings"
 )
 
+// "enum" for parts, below.
+const (
+	literal    = iota
+	singleStar = iota
+	doubleStar = iota
+)
+
 type part struct {
-	// 0, 1, or 2
-	stars int8
-	// only set if stars == 0
+	kind int8
+	// only set if kind == literal
 	lit string
 }
 
 var starstar part = part{
-	stars: 2,
-	lit:   "",
+	kind: doubleStar,
+	lit:  "",
 }
 
 var star part = part{
-	stars: 1,
-	lit:   "",
+	kind: singleStar,
+	lit:  "",
 }
 
 type Glob struct {
@@ -46,8 +52,8 @@ func Compile(glob string) Glob {
 			parts = append(parts, star)
 		} else {
 			parts = append(parts, part{
-				stars: 0,
-				lit:   fragment,
+				kind: literal,
+				lit:  fragment,
 			})
 		}
 	}
@@ -61,7 +67,7 @@ func Compile(glob string) Glob {
 // albeit with the single-character wildcard removed (since I don't
 // believe we need it.) For more details:
 //
-//   https://research.swtch.com/glob
+//	https://research.swtch.com/glob
 func match(pattern, name string) bool {
 	px := 0
 	nx := 0
@@ -132,8 +138,8 @@ func (g *Glob) Match(path string) bool {
 
 		if px < len(g.parts) {
 			c := g.parts[px]
-			switch c.stars {
-			case 0:
+			switch c.kind {
+			case literal:
 				if nx < len(path) {
 					// find the next substring
 					var chunk string
@@ -149,12 +155,12 @@ func (g *Glob) Match(path string) bool {
 						continue
 					}
 				}
-			case 2:
+			case doubleStar:
 				nextPx = px
 				nextNx = incrNx
 				px++
 				continue
-			case 1:
+			case singleStar:
 				if nx < len(path) {
 					px++
 					nx = incrNx

--- a/oh_my_glob.go
+++ b/oh_my_glob.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+// "enum" for globs.
+const (
+	generalParts = iota
+)
+
 // "enum" for parts, below.
 const (
 	// Something that is not a literal `*` or `**`, but makes no other
@@ -35,6 +40,7 @@ var star part = part{
 type Glob struct {
 	// this is for pretty-printing the glob
 	original string
+	kind     int8
 	// we pre-break the glob at `/` boundaries for less processing
 	// later
 	parts []part
@@ -65,6 +71,7 @@ func Compile(glob string) Glob {
 	}
 	return Glob{
 		original: glob,
+		kind:     generalParts,
 		parts:    parts,
 	}
 }
@@ -113,7 +120,7 @@ func match(pattern, name string) bool {
 	return true
 }
 
-func (g *Glob) Match(path string) bool {
+func (g *Glob) matchGeneral(path string) bool {
 	// `px` is the index into the current path part
 	px := 0
 	// `nx` is the index into the string, which will change in
@@ -191,4 +198,14 @@ func (g *Glob) Match(path string) bool {
 		return false
 	}
 	return true
+}
+
+func (g *Glob) Match(path string) bool {
+	switch g.kind {
+	case generalParts:
+		return g.matchGeneral(path)
+	default:
+		log.Fatalf("Unexpected compiled glob kind")
+		return false
+	}
 }

--- a/oh_my_glob.go
+++ b/oh_my_glob.go
@@ -44,8 +44,9 @@ func Compile(glob string) Glob {
 		}
 	}
 
-	var parts []part
-	for _, fragment := range strings.Split(glob, "/") {
+	fragments := strings.Split(glob, "/")
+	parts := make([]part, 0, len(fragments))
+	for _, fragment := range fragments {
 		if fragment == "**" {
 			parts = append(parts, starstar)
 		} else if fragment == "*" {

--- a/oh_my_glob.go
+++ b/oh_my_glob.go
@@ -10,6 +10,8 @@ const (
 	generalParts = iota
 	// **/*.suffix
 	recursiveWildcardSuffix = iota
+	// **/filename
+	recursiveWildcardFixedFile = iota
 )
 
 // "enum" for parts, below.
@@ -99,6 +101,18 @@ func Compile(glob string) Glob {
 				return Glob{
 					original: glob,
 					kind:     recursiveWildcardSuffix,
+					parts:    parts,
+				}
+			}
+
+			// Matching the special case of **/filename.
+			p := parts[len(parts)-1]
+			if p.kind == literal && p.no_stars {
+				parts[0] = p
+				parts = parts[:1]
+				return Glob{
+					original: glob,
+					kind:     recursiveWildcardFixedFile,
 					parts:    parts,
 				}
 			}
@@ -241,12 +255,30 @@ func (g *Glob) matchRecursiveWildcardSuffix(path string) bool {
 	return strings.HasSuffix(path, g.parts[0].lit)
 }
 
+func (g *Glob) matchRecursiveWildcardFixedFile(path string) bool {
+	// We need to handle two cases:
+	//
+	// 1. path/to/dir/filename
+	// 2. filename
+	if !strings.HasSuffix(path, g.parts[0].lit) {
+		return false
+	}
+
+	if len(path) == len(g.parts[0].lit) {
+		return true
+	}
+
+	return path[len(path)-len(g.parts[0].lit)-1] == '/'
+}
+
 func (g *Glob) Match(path string) bool {
 	switch g.kind {
 	case generalParts:
 		return g.matchGeneral(path)
 	case recursiveWildcardSuffix:
 		return g.matchRecursiveWildcardSuffix(path)
+	case recursiveWildcardFixedFile:
+		return g.matchRecursiveWildcardFixedFile(path)
 	default:
 		log.Fatalf("Unexpected compiled glob kind")
 		return false

--- a/oh_my_glob_test.go
+++ b/oh_my_glob_test.go
@@ -57,6 +57,14 @@ func BenchmarkNegativeRecursiveFixedFile(b *testing.B) {
 	benchmarkMatch(b, "**/__package.rb", "dev/lib/the_cmd/commands/build_from_scratch.rb")
 }
 
+func BenchmarkFixedPathWildcardFile(b *testing.B) {
+	benchmarkMatch(b, "dev/lib/the_cmd/commands/*.yaml", "dev/lib/the_cmd/commands/commands.yaml")
+}
+
+func BenchmarkNegativeFixedPathWildcardFile(b *testing.B) {
+	benchmarkMatch(b, "dev/lib/the_cmd/commands/*.yaml", "dev/lib/the_cmd/commands/build_from_scratch.rb")
+}
+
 func TestBasicGlob(t *testing.T) {
 	// basic string equality
 	testCase(t, "what", "what", true)

--- a/oh_my_glob_test.go
+++ b/oh_my_glob_test.go
@@ -49,6 +49,14 @@ func BenchmarkNegativeSubdirFromRoot(b *testing.B) {
 	benchmarkMatch(b, "**/*.yaml", "dev/lib/the_cmd/commands/build_from_scratch.rb")
 }
 
+func BenchmarkPrefixedSubdirFromRoot(b *testing.B) {
+	benchmarkMatch(b, "dev/**/*.yaml", "dev/lib/the_cmd/commands/commands.yaml")
+}
+
+func BenchmarkNegativePrefixedSubdirFromRoot(b *testing.B) {
+	benchmarkMatch(b, "dev/**/*.yaml", "dev/lib/the_cmd/commands/build_from_scratch.rb")
+}
+
 func BenchmarkRecursiveFixedFile(b *testing.B) {
 	benchmarkMatch(b, "**/__package.rb", "dev/lib/the_cmd/commands/__package.rb")
 }

--- a/oh_my_glob_test.go
+++ b/oh_my_glob_test.go
@@ -65,6 +65,14 @@ func BenchmarkNegativeRecursiveFixedFile(b *testing.B) {
 	benchmarkMatch(b, "**/__package.rb", "dev/lib/the_cmd/commands/build_from_scratch.rb")
 }
 
+func BenchmarkPrefixedRecursiveFixedFile(b *testing.B) {
+	benchmarkMatch(b, "dev/**/__package.rb", "dev/lib/the_cmd/commands/__package.rb")
+}
+
+func BenchmarkNegativePrefixedRecursiveFixedFile(b *testing.B) {
+	benchmarkMatch(b, "dev/**/__package.rb", "dev/lib/the_cmd/commands/build_from_scratch.rb")
+}
+
 func BenchmarkFixedPathWildcardFile(b *testing.B) {
 	benchmarkMatch(b, "dev/lib/the_cmd/commands/*.yaml", "dev/lib/the_cmd/commands/commands.yaml")
 }

--- a/oh_my_glob_test.go
+++ b/oh_my_glob_test.go
@@ -153,3 +153,10 @@ func TestCombined(t *testing.T) {
 
 	testCase(t, "**/*.conf", "config/this/that/foo.conf", true)
 }
+
+func TestWildcardSuffix(t *testing.T) {
+	testCase(t, "config/*.conf", "config/foo.conf", true)
+	testCase(t, "config/*.conf", "config/this/foo.conf", false)
+	testCase(t, "config/*.conf", "config/this/that/foo.conf", false)
+	testCase(t, "config/*.conf", "something/else.conf", false)
+}

--- a/oh_my_glob_test.go
+++ b/oh_my_glob_test.go
@@ -49,6 +49,14 @@ func BenchmarkNegativeSubdirFromRoot(b *testing.B) {
 	benchmarkMatch(b, "**/*.yaml", "dev/lib/the_cmd/commands/build_from_scratch.rb")
 }
 
+func BenchmarkWildcardTail(b *testing.B) {
+	benchmarkMatch(b, "dev/lib/the_cmd/commands/*", "dev/lib/the_cmd/commands/commands.yaml")
+}
+
+func BenchmarkNegativeWildcardTail(b *testing.B) {
+	benchmarkMatch(b, "dev/lib/the_cmd/commands/*", "ved/bil/dmc_eht/sdnammoc/blah")
+}
+
 func BenchmarkPrefixedSubdirFromRoot(b *testing.B) {
 	benchmarkMatch(b, "dev/**/*.yaml", "dev/lib/the_cmd/commands/commands.yaml")
 }


### PR DESCRIPTION
(This is stacked on top of #6, which should land before this one)

This PR adds support for recognizing a number of special cases that come up when using this library inside Stripe.  The general idea is to try and recognize when we can match fixed strings and can therefore avoid doing wildcard matching, which is relatively slow.  There's no better advertisement for this PR than benchmarks.

Before:

```
st-froydnj2:oh-my-glob froydnj$ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/aisamanra/oh-my-glob
BenchmarkCompileLiteralPaths-10                   	 5092194	       226.8 ns/op
BenchmarkLiteralPaths-10                          	16395495	        72.81 ns/op
BenchmarkCompileSubdirFromRoot-10                 	11120170	       107.5 ns/op
BenchmarkSubdirFromRoot-10                        	 7697340	       155.4 ns/op
BenchmarkNegativeSubdirFromRoot-10                	 6224624	       191.6 ns/op
BenchmarkWildcardTail-10                          	20668110	        58.00 ns/op
BenchmarkNegativeWildcardTail-10                  	149957659	         8.088 ns/op
BenchmarkPrefixedSubdirFromRoot-10                	 8335209	       147.8 ns/op
BenchmarkNegativePrefixedSubdirFromRoot-10        	 6492579	       184.7 ns/op
BenchmarkRecursiveFixedFile-10                    	15406861	        77.57 ns/op
BenchmarkNegativeRecursiveFixedFile-10            	17431472	        69.02 ns/op
BenchmarkPrefixedRecursiveFixedFile-10            	15709068	        75.71 ns/op
BenchmarkNegativePrefixedRecursiveFixedFile-10    	17513240	        68.23 ns/op
BenchmarkFixedPathWildcardFile-10                 	13283317	        89.93 ns/op
BenchmarkNegativeFixedPathWildcardFile-10         	 9711602	       125.5 ns/op
PASS
ok  	github.com/aisamanra/oh-my-glob	20.645s
```

After:

```
st-froydnj2:oh-my-glob froydnj$ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/aisamanra/oh-my-glob
BenchmarkCompileLiteralPaths-10                   	 8773447	       129.8 ns/op
BenchmarkLiteralPaths-10                          	24043117	        50.12 ns/op
BenchmarkCompileSubdirFromRoot-10                 	15144303	        78.47 ns/op
BenchmarkSubdirFromRoot-10                        	251199892	         4.753 ns/op
BenchmarkNegativeSubdirFromRoot-10                	269765800	         4.443 ns/op
BenchmarkWildcardTail-10                          	25591287	        46.15 ns/op
BenchmarkNegativeWildcardTail-10                  	98802025	        12.04 ns/op
BenchmarkPrefixedSubdirFromRoot-10                	169671831	         7.058 ns/op
BenchmarkNegativePrefixedSubdirFromRoot-10        	267510488	         4.465 ns/op
BenchmarkRecursiveFixedFile-10                    	236579434	         5.079 ns/op
BenchmarkNegativeRecursiveFixedFile-10            	251166747	         4.824 ns/op
BenchmarkPrefixedRecursiveFixedFile-10            	147275894	         8.171 ns/op
BenchmarkNegativePrefixedRecursiveFixedFile-10    	245319800	         5.128 ns/op
BenchmarkFixedPathWildcardFile-10                 	100000000	        11.22 ns/op
BenchmarkNegativeFixedPathWildcardFile-10         	227851381	         5.576 ns/op
PASS
ok  	github.com/aisamanra/oh-my-glob	23.455s
```

Maybe not the greatest format for eyeballing comparisons, but nearly all the matching benchmarks drop by at least an order of magnitude with some cases closer to 15-20x faster; the `WildcardTail` benchmarks are the exception because I haven't added special cases for them yet.

A slightly earlier version of this branch cuts the time of the globbing step for Stripe's codebase by ~40%.  I'm very excited to see the full version land!